### PR TITLE
Create new contract documentation and tutorials

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -1,0 +1,17 @@
+---
+title: OpenZeppelin Confidential Contracts – Guides
+---
+
+# Guides
+
+This folder contains standalone, markdown-based documentation for using the contracts in this repository. It does not depend on the existing `docs/` site and can be browsed directly in Git or rendered by any static site generator that supports markdown.
+
+Contents:
+
+- Getting Started: `getting-started.md`
+- ERC7984 Overview: `erc7984-overview.md`
+- ERC7984 Quickstart: `erc7984-quickstart.md`
+- Extensions Guide: `extensions.md`
+- Vesting Tutorial: `vesting-wallet.md`
+- Advanced ACL & Input Proofs: `advanced-acl.md`
+

--- a/guides/advanced-acl.md
+++ b/guides/advanced-acl.md
@@ -1,0 +1,29 @@
+# Advanced: FHE ACL and Input Proofs
+
+Many functions in this repo accept `externalEuint64` (and related types) plus an `inputProof`. Others accept encrypted types (`euint64`) directly and require that the caller already has ACL access to those values.
+
+Key concepts:
+
+- `FHE.fromExternal(externalEuint64, inputProof)`: Converts an external ciphertext to an encrypted handle, validating the input proof via the fhEVM gateway
+- `FHE.isAllowed(handle, account)`: Checks whether `account` can use `handle`
+- `FHE.allow(handle, account)`, `FHE.allowTransient(handle, account)`: Grants persistent or transient access to a handle
+- `FHE.requestDecryption(handles, callbackSelector)`: Initiates asynchronous decryption, later completed via a finalize function
+- `FHE.checkSignatures(requestId, signatures)`: Verifies the gateway signatures on decryption results
+
+Patterns:
+
+- Function variants: many APIs have both `externalEuint64 + inputProof` and `euint64` variants
+- Use `allowTransient` for one-off internal flows (e.g., passing amount to token contract)
+- When moving values across contracts, ensure appropriate `allow` calls are made for each recipient
+
+Examples in repo:
+
+- `ERC7984.confidentialTransfer` and `confidentialTransferFrom` function pairs
+- `ERC7984.discloseEncryptedAmount` + `finalizeDiscloseEncryptedAmount`
+- `ERC7984ERC20Wrapper.unwrap` + `finalizeUnwrap`
+- `SwapConfidentialToERC20` using `requestDecryption`/`finalizeSwap`
+
+Troubleshooting:
+
+- Unauthorized use errors typically indicate missing ACL allowance or missing/invalid input proofs
+- Ensure the correct contract addresses are allowed when values are passed between contracts

--- a/guides/erc7984-overview.md
+++ b/guides/erc7984-overview.md
@@ -1,0 +1,25 @@
+# ERC7984 Overview
+
+ERC7984 is a draft interface for confidential fungible tokens powered by the Zama fhEVM. Balances and transfers use encrypted integers (`euint64`) so amounts are not publicly visible onchain.
+
+Core concepts:
+
+- Confidential balances via `confidentialBalanceOf(address)`
+- Confidential total supply via `confidentialTotalSupply()`
+- Confidential transfers with and without input proofs
+- Operators via `setOperator(holder, operator, until)` and `isOperator(holder, spender)`
+- Optional transfer-and-call flow via `IERC7984Receiver`
+
+Events:
+
+- `ConfidentialTransfer(address from, address to, euint64 amount)`
+- `OperatorSet(address holder, address operator, uint48 until)`
+- `AmountDisclosed(euint64 encryptedAmount, uint64 amount)` (optional flow to disclose)
+
+Integration notes:
+
+- Without an input proof, callers must already have ACL access to given encrypted values
+- With an input proof, the fhEVM gateway authorizes access dynamically
+- When using transfer-and-call, the receiver returns an encrypted boolean (`ebool`) to indicate success
+
+See the Quickstart for deployment and usage examples.

--- a/guides/erc7984-quickstart.md
+++ b/guides/erc7984-quickstart.md
@@ -1,0 +1,86 @@
+# ERC7984 Quickstart
+
+This quickstart shows how to deploy a simple `ERC7984` token and perform confidential transfers using input proofs.
+
+Example token contract used here: `contracts/mocks/docs/ERC7984MintableBurnable.sol`.
+
+## 1) Deploy a token
+
+Constructor: `ERC7984MintableBurnable(address owner, string name, string symbol, string uri)`
+
+Example Hardhat script snippet:
+
+```ts
+import { ethers } from "hardhat";
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  const Token = await ethers.getContractFactory("ERC7984MintableBurnable");
+  const token = await Token.deploy(deployer.address, "ConfToken", "CONF", "ipfs://token-metadata");
+  await token.waitForDeployment();
+  console.log("Token:", await token.getAddress());
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+
+## 2) Mint with input proof
+
+The token owner can mint using an `externalEuint64` encrypted amount plus an `inputProof` provided by the fhEVM gateway.
+
+```solidity
+// Solidity example (owner context)
+function mint(address to, externalEuint64 amount, bytes memory inputProof) public onlyOwner {
+    _mint(to, FHE.fromExternal(amount, inputProof));
+}
+```
+
+High-level flow:
+
+- Obtain `amount` ciphertext and `inputProof` from the fhEVM gateway
+- Call `mint(to, amount, inputProof)`
+
+## 3) Confidential transfer with proof
+
+Two ways to transfer:
+
+- With proof: `confidentialTransfer(to, externalEuint64, bytes inputProof)`
+- Without proof: `confidentialTransfer(to, euint64)` if caller already has ACL access to the encrypted amount
+
+Example with proof:
+
+```ts
+// TypeScript sketch
+const { ciphertext, inputProof } = await getProofFromGateway(/* amount = 100 */);
+await token.confidentialTransfer(recipient, ciphertext, inputProof);
+```
+
+## 4) Transfer and call
+
+If the receiver implements `IERC7984Receiver`, you can call:
+
+```ts
+await token.confidentialTransferAndCall(receiver, ciphertext, inputProof, "0x");
+```
+
+The receiver’s `onConfidentialTransferReceived` returns `ebool`. If false, the transfer must be reverted by the token and the funds are effectively refunded.
+
+## 5) Operators
+
+Grant an operator that can move funds until a timestamp:
+
+```ts
+await token.setOperator(operator, Math.floor(Date.now()/1000) + 3600);
+```
+
+Then the operator can use `confidentialTransferFrom(from, to, ...)` variants.
+
+## 6) Balance and supply (encrypted)
+
+```ts
+const eSupply = await token.confidentialTotalSupply();
+const eBal = await token.confidentialBalanceOf(user);
+// These are encrypted handles. Use fhEVM gateway flows to disclose if necessary.
+```
+
+See `mocks/docs/SwapERC7984ToERC20.sol` and `mocks/docs/SwapERC7984ToERC7984.sol` for advanced, real-world patterns.

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -1,0 +1,48 @@
+# Extensions
+
+This repository includes several `ERC7984` extensions for common patterns.
+
+## Freezable (`ERC7984Freezable`)
+
+- Track a confidential frozen balance per account via `confidentialFrozen(address)`
+- `confidentialAvailable(address)` returns encrypted available balance (balance minus frozen)
+- Internal `_setConfidentialFrozen(address, euint64)` to update frozen amounts
+- Override `_checkFreezer()` to restrict who can freeze/unfreeze
+- Transfer updates respect frozen amounts by overriding `_update`
+
+Use case: DAO/multisig can freeze a confidential amount during investigations or to implement vesting-like holds.
+
+## Restricted (`ERC7984Restricted`)
+
+- Model user restrictions via `Restriction` enum: `DEFAULT`, `BLOCKED`, `ALLOWED`
+- `isUserAllowed(address)` returns whether an account can send/receive
+- Override to implement an allowlist instead of blocklist
+- Internal helpers `_blockUser`, `_allowUser`, `_resetUser`
+- Transfers enforce restrictions in `_update`
+
+Use case: compliance or phased rollouts.
+
+## Votes (`ERC7984Votes`)
+
+- Integrates with `VotesConfidential` to track voting units equal to encrypted balance
+- Delegation flows mirror standard OZ Votes, but using encrypted units
+- Overrides `_update` to move voting units when balances change
+
+Use case: confidential governance where balances map to voting power.
+
+## Omnibus (`ERC7984Omnibus`)
+
+- Adds events that carry encrypted sub-account sender/recipient (`eaddress`)
+- Helpers to perform omnibus transfers and emit `OmnibusConfidentialTransfer`
+- Integrators keep offchain accounting for sub-accounts; onchain settlement remains standard
+
+Use case: exchanges/custodians with omnibus wallets while preserving confidentiality of sub-accounts.
+
+## ERC20 Wrapper (`ERC7984ERC20Wrapper`)
+
+- Wrap a standard `ERC20` into an `ERC7984` with a conversion `rate()` and adjusted `decimals()`
+- `onTransferReceived` supports `ERC1363` flows to auto-wrap on receipt
+- `wrap(to, amount)` and `unwrap(from, to, euint64)` with asynchronous decryption via `finalizeUnwrap`
+- Not suitable for non-standard tokens (fee-on-transfer, rebasing without care)
+
+Use case: onboarding ERC20 liquidity into confidential tokens.

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -1,0 +1,40 @@
+# Getting Started
+
+This repository provides experimental building blocks for confidential smart contracts on the Zama fhEVM coprocessor. Contracts use homomorphically encrypted types (for example, `euint64`) from `@fhevm/solidity` to keep token amounts and other values confidential onchain.
+
+Prerequisites:
+
+- Node.js >= 20
+- Hardhat ^2.24
+- Access to an fhEVM-enabled network and the Zama gateway/relayer
+
+Install dependencies:
+
+```bash
+npm ci
+```
+
+Compile contracts:
+
+```bash
+npm run compile
+```
+
+Run tests:
+
+```bash
+npm test
+```
+
+Key packages used:
+
+- `@fhevm/solidity` for FHE types and operations
+- `ethers` v6 and Hardhat plugins
+
+Next steps:
+
+- Read the ERC7984 overview to understand the confidential fungible token interface
+- Follow the quickstart to deploy a token and perform confidential transfers
+- Explore extensions and tutorials for common patterns
+
+> Important: This code is experimental and unaudited. Use at your own risk.

--- a/guides/vesting-wallet.md
+++ b/guides/vesting-wallet.md
@@ -1,0 +1,78 @@
+# Vesting Wallet (Confidential)
+
+`VestingWalletConfidential` receives `ERC7984` tokens and releases them to the beneficiary according to a confidential, linear vesting schedule.
+
+Highlights:
+
+- Ownable and upgradeable pattern
+- Tracks released amounts per token as `euint128`
+- `releasable(token)` returns encrypted amount vested so far
+- `release(token)` transfers vested amount to owner and updates released total
+- Designed to be deployed as clones via `VestingWalletConfidentialFactory`
+
+## Using the Wallet
+
+Initialization (called in your implementation):
+
+```solidity
+function __VestingWalletConfidential_init(
+  address beneficiary,
+  uint48 startTimestamp,
+  uint48 durationSeconds
+) internal onlyInitializing;
+```
+
+Vesting math:
+
+- Linear schedule by default: vested from `start` to `end = start + duration`
+- Override `_vestingSchedule(euint128 totalAllocation, uint48 timestamp)` for custom curves
+
+Release flow:
+
+```solidity
+function release(address token) public {
+  euint64 amount = releasable(token);
+  FHE.allowTransient(amount, token);
+  euint64 sent = IERC7984(token).confidentialTransfer(owner(), amount);
+  // Update released total (encrypted) and emit event
+}
+```
+
+## Factory for Batch Funding
+
+`VestingWalletConfidentialFactory` lets you fund multiple wallets in batch and deploy clones deterministically.
+
+Key pieces:
+
+- `struct VestingPlan { externalEuint64 encryptedAmount; bytes initArgs; }`
+- `batchFundVestingWalletConfidential(address token, VestingPlan[] plans, bytes inputProof)`
+- `createVestingWalletConfidential(bytes initArgs)` and `predictVestingWalletConfidential(bytes initArgs)`
+
+You must implement:
+
+- `_deployVestingWalletImplementation()` once (returns implementation address)
+- `_initializeVestingWallet(address wallet, bytes calldata initArgs)` to decode and initialize clones
+- `_validateVestingWalletInitArgs(bytes memory initArgs)` to sanity check init args
+
+Typical `initArgs` can be ABI-encoded `(beneficiary, start, duration)`.
+
+### Example init args
+
+```solidity
+bytes memory initArgs = abi.encode(beneficiary, uint48(start), uint48(duration));
+```
+
+Then in your factory implementation:
+
+```solidity
+function _initializeVestingWallet(address wallet, bytes calldata initArgs) internal override {
+  (address beneficiary, uint48 start, uint48 duration) = abi.decode(initArgs, (address, uint48, uint48));
+  VestingWalletConfidential(payable(wallet)).__VestingWalletConfidential_init(beneficiary, start, duration);
+}
+```
+
+Batch fund flow:
+
+- Gateway provides input proof for each `VestingPlan.encryptedAmount`
+- Contract transfers confidential amounts to predicted wallet addresses
+- You can deploy the clones before or after funding (deterministic address)


### PR DESCRIPTION
Add new markdown guides and tutorials for using the confidential contracts in a dedicated `guides/` folder, separate from existing documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-28f0ea8f-b42b-44ca-85b3-649080735ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-28f0ea8f-b42b-44ca-85b3-649080735ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

